### PR TITLE
Pull Casacore module into submodule; and create LibCasacore for raw C++ objects/methods

### DIFF
--- a/Casacore/.gitignore
+++ b/Casacore/.gitignore
@@ -1,0 +1,1 @@
+/Manifest.toml

--- a/Casacore/LICENSE
+++ b/Casacore/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Kirin Shila <me@kiranshila>, Torrance Hodgson <torrance@pravic.xyz> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Casacore/Project.toml
+++ b/Casacore/Project.toml
@@ -1,0 +1,17 @@
+name = "Casacore"
+uuid = "72bb1062-94f5-49fa-bb69-94b615203ad9"
+authors = ["Kirin Shila <me@kiranshila>", "Torrance Hodgson <torrance@pravic.xyz>", "and contributors"]
+version = "0.1.0"
+
+[deps]
+CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
+jlcasacore_jll = "288d454e-76cd-513d-9a6f-0ef9fadc4958"
+
+[compat]
+julia = "1.8"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Casacore/README.md
+++ b/Casacore/README.md
@@ -1,0 +1,1 @@
+# Casacore

--- a/Casacore/src/Casacore.jl
+++ b/Casacore/src/Casacore.jl
@@ -1,0 +1,5 @@
+module Casacore
+
+include("LibCasacore.jl")
+
+end

--- a/Casacore/src/LibCasacore.jl
+++ b/Casacore/src/LibCasacore.jl
@@ -1,7 +1,7 @@
-module CasaCore
+module LibCasacore
 
-using jlcasacore_jll
 using CxxWrap
+using jlcasacore_jll
 
 @wrapmodule(libjlcasacore)
 

--- a/Casacore/test/runtests.jl
+++ b/Casacore/test/runtests.jl
@@ -1,0 +1,6 @@
+using Casacore
+using Test
+
+@testset "Casacore.jl" begin
+    # Write your tests here.
+end


### PR DESCRIPTION
A little reorganisation of code: create a module proper for Casacore, and pull the CxxWrap methods inside a submodule.

The CxxWrap methods can be exposed by friendly wrappers and abstractions.